### PR TITLE
Black SVG icon for Apple Safari retrieved instead of "real" icon

### DIFF
--- a/src/FaviconDownloader.php
+++ b/src/FaviconDownloader.php
@@ -101,6 +101,7 @@ class FaviconDownloader
         
         // Default favicon URL
         $this->icoUrl = $this->siteUrl.'favicon.ico';
+        $this->icoType = 'ico';
         $this->findMethod = 'default';
         
         // HTML <head> tag extraction

--- a/src/FaviconDownloader.php
+++ b/src/FaviconDownloader.php
@@ -116,8 +116,8 @@ class FaviconDownloader
         }
         
         // HTML <link> icon tag analysis
-        // @see http://stackoverflow.com/a/171499/209184
-        if (preg_match_all('#<\\s*link[^>]*(rel=(["\'])(\\\\?.)*?icon*?\\2)[^>]*>#i', $htmlHead, $matches)) {
+        // @see https://github.com/gokercebeci/geticon/blob/master/class.geticon.php#L66
+        if (preg_match_all('#<([^>]*)link([^>]*)rel\=("|\')?(icon|shortcut icon)("|\')?([^>]*)>#iU', $htmlHead, $matches)) {
             $link_tag = end($matches[0]);
             $this->debugInfo['link_tag'] = $link_tag;
             

--- a/src/FaviconDownloader.php
+++ b/src/FaviconDownloader.php
@@ -115,7 +115,8 @@ class FaviconDownloader
         }
         
         // HTML <link> icon tag analysis
-        if (preg_match_all('#<\s*link[^>]*(rel=(["\'])[^>\2]*icon[^>\2]*\2)[^>]*>#i', $htmlHead, $matches)) {
+        // @see http://stackoverflow.com/a/171499/209184
+        if (preg_match_all('#<\\s*link[^>]*(rel=(["\'])(\\\\?.)*?icon*?\\2)[^>]*>#i', $htmlHead, $matches)) {
             $link_tag = end($matches[0]);
             $this->debugInfo['link_tag'] = $link_tag;
             

--- a/src/FaviconDownloader.php
+++ b/src/FaviconDownloader.php
@@ -115,8 +115,8 @@ class FaviconDownloader
         }
         
         // HTML <link> icon tag analysis
-        if (preg_match('#<\s*link[^>]*(rel=(["\'])[^>\2]*icon[^>\2]*\2)[^>]*>#i', $htmlHead, $matches)) {
-            $link_tag = $matches[0];
+        if (preg_match_all('#<\s*link[^>]*(rel=(["\'])[^>\2]*icon[^>\2]*\2)[^>]*>#i', $htmlHead, $matches)) {
+            $link_tag = end($matches[0]);
             $this->debugInfo['link_tag'] = $link_tag;
             
             // HTML <link> icon tag href analysis


### PR DESCRIPTION
Apple introduced the concept of "pinned tab icons" for Safari 9, and it recommends placing this rel=icon link first, before the regular favicon: https://developer.apple.com/library/safari/releasenotes/General/WhatsNewInSafari/Articles/Safari_9.html#//apple_ref/doc/uid/TP40014305-CH9-SW20

The current code retrieves the first match, which may end up being the pinned tab icon. In some cases, e.g. Twitter and Flickr, this SVG icon is black instead of colored.

Fixed this to retrieve the last rel=icon link instead.
